### PR TITLE
NXP-21432: Realign with last AWS SDK - add corruption test

### DIFF
--- a/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/CloudFrontBinaryManager.java
+++ b/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/CloudFrontBinaryManager.java
@@ -38,7 +38,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.PEM;
 import com.amazonaws.auth.RSA;
 import com.amazonaws.services.cloudfront.CloudFrontUrlSigner;
-import com.amazonaws.services.cloudfront.CloudFrontUrlSigner.Protocol;
+import com.amazonaws.services.cloudfront.util.SignerUtils.Protocol;
 import com.amazonaws.util.IOUtils;
 
 /**
@@ -115,7 +115,7 @@ public class CloudFrontBinaryManager extends S3BinaryManager {
     }
 
     private String buildResourcePath(String s3ObjectKey) {
-        return protocol != CloudFrontUrlSigner.Protocol.http && protocol != CloudFrontUrlSigner.Protocol.https
+        return protocol != Protocol.http && protocol != Protocol.https
                 ? s3ObjectKey : protocol + "://" + distributionDomain + "/" + s3ObjectKey;
     }
 

--- a/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3BinaryManager.java
+++ b/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3BinaryManager.java
@@ -469,8 +469,8 @@ public class S3BinaryManager extends AbstractCloudBinaryManager {
                 // Check ETag it is by default MD5 if not multipart
                 if (!isEncrypted && !digest.equals(download.getObjectMetadata().getETag())) {
                     // In case of multipart it will happen, verify the downloaded file
-                    String currentDigest = "";
-                    try(FileInputStream input = new FileInputStream(file)) {
+                    String currentDigest;
+                    try (FileInputStream input = new FileInputStream(file)) {
                         currentDigest = DigestUtils.md5Hex(input);
                     }
                     if (!currentDigest.equals(digest)) {

--- a/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3BinaryManager.java
+++ b/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3BinaryManager.java
@@ -163,6 +163,27 @@ public class TestS3BinaryManager extends AbstractS3BinaryTest<S3BinaryManager> {
 
     @Override
     @Test
+    public void testStoreFile() throws Exception {
+        // Run normal test
+        super.testStoreFile();
+        // Run corruption test
+        String key = binaryManager.bucketNamePrefix + CONTENT_MD5;
+        binaryManager.amazonS3.putObject(binaryManager.bucketName, key, "Georges Abitbol");
+        binaryManager.fileCache.clear();
+        Boolean exceptionOccured = false;
+        try {
+            binaryManager.getBinary(CONTENT_MD5).getStream();
+        } catch (RuntimeException e) {
+            // Should not be wrapped in a RuntimeException as it declare the IOException
+            if (e.getCause() instanceof IOException) {
+                exceptionOccured = true;
+            }
+        }
+        assertTrue("IOException should occured as content is corrupted", exceptionOccured);
+    }
+    
+    @Override
+    @Test
     public void testBinaryManagerGC() throws Exception {
         if (binaryManager.bucketNamePrefix.isEmpty()) {
             // no additional test if no bucket name prefix


### PR DESCRIPTION
When using Upload with S3 library the check is done on all the subpart by UploadPartRequest, it is then not necessary to recheck the MD5 again, in case of download i use by default the Etag but if it fails then i verify directly from the file downloaded ( case of a multipart , we might dont want that as multipart is probably bigger file )