### PR TITLE
Fixed Build Status URL

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,7 @@ For efficiency, a local disk cache (with limited size) is also used.
 
 ## QA results
 
-[![Build Status](https://qa.nuxeo.org/jenkins/buildStatus/icon?job=addons_nuxeo-core-binarymanager-cloud-master)](https://qa.nuxeo.org/jenkins/job/addons_nuxeo-core-binarymanager-cloud-master/)
+[![Build Status](https://qa.nuxeo.org/jenkins/buildStatus/icon?job=addons_nuxeo-core-binarymanager-cloud-master)](https://qa.nuxeo.org/jenkins/job/master/job/addons_nuxeo-core-binarymanager-cloud-master/)
 
 # About Nuxeo
 


### PR DESCRIPTION
Jenkins returned 404 for linked URL
Suggesting https://qa.nuxeo.org/jenkins/job/master/job/addons_nuxeo-core-binarymanager-cloud-master/ as the correct one